### PR TITLE
Add adjustable opacity to tethers. Also fix planet transparency missing commit.

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,22 +138,26 @@
           }          
         </script>
         <script id="tetherVertexShader" type="x-shader/x-vertex">
-          attribute vec3 center;
-          varying vec3 vCenter;
+          varying float eyeDistance; // the distance in meters from the camera the current geometry fragment is
           void main() {
-            vCenter = center;
-            gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+            // save a little computation by storing and reusing eye coordinates
+            vec4 eyeCoord = modelViewMatrix * vec4(position, 1.0);
+            gl_Position = projectionMatrix * eyeCoord;
+            // WebGL is a right handed coordinate system where eye coordinates
+            // face down the negative z axis. the inverse square means we don't
+            // need to negate this, but better to be clear.
+            eyeDistance = -eyeCoord.z;
           }
         </script>
         <script id="tetherFragmentShader" type="x-shader/x-fragment">
-          uniform float thickness;
-          varying vec3 vCenter;
+          uniform float opacityFactor;
+          uniform float baseOpacity;
+          varying float eyeDistance;
           void main() {
-            vec3 afwidth = fwidth( vCenter.xyz );
-            vec3 edge3 = smoothstep( ( thickness - 1.0 ) * afwidth, thickness * afwidth, vCenter.xyz );
-            float edge = 1.0 - min( min( edge3.x, edge3.y ), edge3.z );
-            gl_FragColor.rgb = gl_FrontFacing ? vec3( 0.9, 0.9, 1.0 ) : vec3( 0.4, 0.4, 0.5 );
-            gl_FragColor.a = edge;
+            float opacityDropOff = opacityFactor / pow(eyeDistance, 2.0);
+            float opacity = baseOpacity + opacityDropOff;
+            gl_FragColor.rgb = vec3(1.0);
+            gl_FragColor.a = opacity;
           }
         </script>
 

--- a/main.js
+++ b/main.js
@@ -508,6 +508,8 @@ const guidParamWithUnits = {
   showEarthsSurface: {value: defaultShows, units: '', autoMap: true, updateFunction: adjustEarthSurfaceVisibility, folder: folderRendering},
   showEarthsAtmosphere: {value: true, units: '', autoMap: true, updateFunction: adjustEarthAtmosphereVisibility, folder: folderRendering},
   earthTextureOpacity: {value: 1, units: '', autoMap: true, min: 0, max: 1, updateFunction: adjustEarthTextureOpacity, folder: folderRendering},
+  tetherBaseOpacity: {value: 1, units: '', autoMap: true, min: 0, max: 1, updateFunction: adjustTetherBaseOpacity, folder: folderRendering},
+  tetherOpacityFactor: {value: 15000, units: '', autoMap: true, min: 1, max: 1e9, updateFunction: adjustTetherOpacityFactor, folder: folderRendering},
   showMoon: {value: defaultShows, units: '', autoMap: true, updateFunction: adjustMoonsVisibility, folder: folderRendering},
   showStars: {value: defaultShows, units: '', autoMap: true, updateFunction: adjustStarsVisibility, folder: folderRendering},
   showEarthAxis: {value: false, units: '', autoMap: true, updateFunction: earthAxisObjectUpdate, folder: folderRendering},
@@ -776,6 +778,18 @@ function adjustEarthTextureOpacity() {
         child.material.opacity = guidParamWithUnits['earthTextureOpacity'].value
     }
   })
+}
+
+function adjustTetherBaseOpacity() {
+  updatedParam()
+  tetherMaterial.uniforms["baseOpacity"].value = guidParamWithUnits['tetherBaseOpacity'].value;
+  tetherMaterial.uniformsNeedUpdate = true
+}
+
+function adjustTetherOpacityFactor() {
+  updatedParam()
+  tetherMaterial.uniforms["opacityFactor"].value = guidParamWithUnits['tetherOpacityFactor'].value;
+  tetherMaterial.uniformsNeedUpdate = true
 }
 
 function adjustDisplacementBias() {
@@ -1257,7 +1271,7 @@ const transparentMaterial1 = new THREE.MeshPhongMaterial( {transparent: true, op
 const transparentMaterial2 = new THREE.MeshLambertMaterial({color: 0xffff80, transparent: true, opacity: 0.35})
 const transparentMaterial3 = new THREE.MeshLambertMaterial({color: 0xffff80, transparent: true, opacity: 0})
 
-var tetherMaterial = new THREE.LineBasicMaterial({
+  /* new THREE.LineBasicMaterial({
   vertexColors: false,
   //color: 0x4897f8,
   //color: 0x000000,
@@ -1265,15 +1279,15 @@ var tetherMaterial = new THREE.LineBasicMaterial({
   color: 0xc0c0f0,
   transparent: true,
   opacity: dParamWithUnits['tetherVisibility'].value
-})
-// const thickness = 2
-// const tetherMaterial = new THREE.ShaderMaterial( {
-//   uniforms: { 'thickness': { value: thickness } },
-//   vertexShader: document.getElementById( 'tetherVertexShader' ).textContent,
-//   fragmentShader: document.getElementById( 'tetherFragmentShader' ).textContent,
-//   side: THREE.DoubleSide,
-//   alphaToCoverage: true // only works when WebGLRenderer's "antialias" is set to "true"
-// } )
+}) */
+const tetherMaterial = new THREE.ShaderMaterial( {
+  uniforms: 
+  { 'baseOpacity': { value: guidParamWithUnits['tetherBaseOpacity'].value  },
+    'opacityFactor': {value: guidParamWithUnits['tetherOpacityFactor'].value }},
+  vertexShader: document.getElementById( 'tetherVertexShader' ).textContent,
+  fragmentShader: document.getElementById( 'tetherFragmentShader' ).textContent,
+  transparent: true,
+} )
 
 var cableMaterial = new THREE.LineBasicMaterial({
   vertexColors: false,

--- a/planet.js
+++ b/planet.js
@@ -18,10 +18,8 @@ export class planet {
       TextureMode24x12 = true
     }
 
-    const useShaders = (dParamWithUnits['earthTextureOpacity'].value!==1)
-    if (dParamWithUnits['earthTextureOpacity'].value!==1 && useShaders) {
-      console.log("Warning useShaders should be set to false when earthTextureOpacity is set less than one.")
-    }
+    // opacity will now work with or without shaders, so warning is not needed.
+    const useShaders = true;
 
     //tetheredRingRefCoordSys.rotation.y = Math.PI/4  // This is done so that the eccentricity adjustment is where we need it to be
     // The above line puts the reference coordinate system's y-axis at lat/lon {0, 0} when RingCenterLat==0 and RingCenterLon==0


### PR DESCRIPTION
This commit adds 2 new render parameters. Base opacity, and opacity factor. Base opacity is the minimum opacity the tethers will have. Opacity factor controls how rapid the fall off is based on the distance from the camera using an inverse square law.

Attached is a screen shot showing an example of how it looks with some example parameter values.
![Screenshot_2023-12-22_13-45-02](https://github.com/philipswan/TetheredRing/assets/29463033/078c51e7-5df7-43b0-a694-bffa7dfe4b60)


