### PR TITLE
Add fork level opacity to the tethers.

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,6 +138,8 @@
           }          
         </script>
         <script id="tetherVertexShader" type="x-shader/x-vertex">
+          attribute float thickness;
+          varying float fThickness;
           varying float eyeDistance; // the distance in meters from the camera the current geometry fragment is
           void main() {
             // save a little computation by storing and reusing eye coordinates
@@ -147,15 +149,17 @@
             // face down the negative z axis. the inverse square means we don't
             // need to negate this, but better to be clear.
             eyeDistance = -eyeCoord.z;
+            fThickness = thickness;
           }
         </script>
         <script id="tetherFragmentShader" type="x-shader/x-fragment">
           uniform float opacityFactor;
           uniform float baseOpacity;
           varying float eyeDistance;
+          varying float fThickness;
           void main() {
             float opacityDropOff = opacityFactor / pow(eyeDistance, 2.0);
-            float opacity = baseOpacity + opacityDropOff;
+            float opacity = (baseOpacity + opacityDropOff) * fThickness;
             gl_FragColor.rgb = vec3(0.0);
             gl_FragColor.a = opacity;
           }


### PR DESCRIPTION
This will add a contribution to opacity based on the cross sectional surface area of a tether.

Right now I'm multiplying the base opacity with fall off by the thickness. But there may be something that looks nicer.

![Screenshot_2024-01-12_11-38-01](https://github.com/philipswan/TetheredRing/assets/29463033/41b17e59-8e61-4aa6-b815-374c5cb22001)
