### PR TITLE
Add displacement maps to earth shader.

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,25 +90,45 @@
       <div id="simContainer" class="w-full">
         <canvas id="c"></canvas>
         <script id="vertexShader" type="x-shader/x-vertex">
-          varying vec2 vertexUV;
-          varying vec3 vertexNormal;
+          uniform bool hasDisplacementMap;
+          uniform float displacementScale;
+          uniform float displacementBias; 
+          uniform sampler2D displacementMap;
+
+          // fragment is the more correct term here,
+          // because it's referring to a pixel sized piece of geometry that might eventually be drawn
+          // the "uv" and "normals" are the vertex uv normals
+          // once they enter the fragment shader they have been rasterized and intermpolated
+          // by the gpu
+          varying vec2 fragmentUV;
+          varying vec3 fragmentNormal;
 
           void main() {
-              vertexUV = uv;
-              vertexNormal = normalize(normalMatrix * normal);
-              gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+              fragmentUV = uv;
+              vec3 vertexNormal = normalize(normalMatrix * normal);
+              fragmentNormal = vertexNormal; // instruct the gpu to interpolate this for the fragment shader
+              if(hasDisplacementMap) {
+                // lifted from three.js' dislacement shader code
+                float displacementOffset = texture2D(displacementMap, uv).x * displacementScale + displacementBias;
+                // displace along the vertex normal
+                vec3 displacement = normalize(normal) * displacementOffset;
+                gl_Position = projectionMatrix * modelViewMatrix * vec4(position + displacement, 1.0);
+              } else {
+                gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+              }
+              
           }
         </script>
         <script id="fragmentShader" type="x-shader/x-fragment">
           uniform sampler2D planetTexture;
           uniform float opacity;
-          varying vec2 vertexUV;
-          varying vec3 vertexNormal;
+          varying vec2 fragmentUV;
+          varying vec3 fragmentNormal;
 
           void main() {
-              float intensity = 1.05 - dot(vertexNormal, vec3(0.0, 0.0, 1.0 ));
+              float intensity = 1.05 - dot(fragmentNormal, vec3(0.0, 0.0, 1.0 ));
               vec3 atmosphere = vec3(0.3, 0.6, 1.0) * pow(intensity, 1.5);
-              gl_FragColor = vec4(atmosphere + texture2D(planetTexture, vertexUV).xyz, opacity);
+              gl_FragColor = vec4(atmosphere + texture2D(planetTexture, fragmentUV).xyz, opacity);
           }          
         </script>
         <script id="fragmentShaderInv" type="x-shader/x-fragment">

--- a/main.js
+++ b/main.js
@@ -811,7 +811,8 @@ function adjustDisplacementBias() {
   planetMeshes.traverse(child => {
     if (child.type==='Mesh') {
       if (child.material.displacementMap) {
-        child.material.displacementBias = guidParamWithUnits['displacementBias'].value
+        child.material.uniforms["displacementBias"].value = guidParamWithUnits['displacementBias'].value
+        child.material.uniformsNeedUpdate = true
       }
     }
   })
@@ -822,7 +823,8 @@ function adjustDisplacementScale() {
   planetMeshes.traverse(child => {
     if (child.type==='Mesh') {
       if (child.material.displacementMap) {
-        child.material.displacementScale = guidParamWithUnits['displacementScale'].value
+        child.material.uniforms["displacementScale"].value = guidParamWithUnits['displacementScale'].value
+        child.material.uniformsNeedUpdate = true
       }
     }
   })

--- a/planet.js
+++ b/planet.js
@@ -19,7 +19,7 @@ export class planet {
     }
 
     // opacity will now work with or without shaders, so warning is not needed.
-    let useShaders = true;
+    const useShaders = true;
 
     //tetheredRingRefCoordSys.rotation.y = Math.PI/4  // This is done so that the eccentricity adjustment is where we need it to be
     // The above line puts the reference coordinate system's y-axis at lat/lon {0, 0} when RingCenterLat==0 and RingCenterLon==0
@@ -56,11 +56,9 @@ export class planet {
 
             if (farFromRing) {
               textureFilename = `./textures/24x12/LR/earth_LR_${w}x${h}_${i}x${j}.jpg`
-              useShaders = true
             }
             else {
               textureFilename = `./textures/24x12/HR/earth_HR_${w}x${h}_${i}x${j}.jpg`
-              useShaders = false
             }
             //console.log(filename)
             const texture = new THREE.TextureLoader().load(textureFilename)
@@ -90,6 +88,18 @@ export class planet {
                   uniforms: {
                     planetTexture: {
                       value: texture,
+                    },
+                    displacementMap: {
+                      value: displacementMap
+                    },
+                    displacementScale: {
+                      value: dParamWithUnits['displacementScale'].value
+                    },
+                    displacementBias: {
+                      value: dParamWithUnits['displacementBias'].value
+                    },
+                    hasDisplacementMap: {
+                      value: displacementMap != null
                     },
                     opacity: { value: dParamWithUnits['earthTextureOpacity'].value }
                   } } ) :


### PR DESCRIPTION
This reintroduces the displacement maps to the shader material that were missing when it was moved off of MeshStandardMaterial.