### PR TITLE
Reinstate previous color scheme

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,9 +126,7 @@
           varying vec3 fragmentNormal;
 
           void main() {
-              float intensity = 1.05 - dot(fragmentNormal, vec3(0.0, 0.0, 1.0 ));
-              vec3 atmosphere = vec3(0.3, 0.6, 1.0) * pow(intensity, 1.5);
-              gl_FragColor = vec4(atmosphere + texture2D(planetTexture, fragmentUV).xyz, opacity);
+              gl_FragColor = vec4(texture2D(planetTexture, fragmentUV).xyz, opacity);
           }          
         </script>
         <script id="fragmentShaderInv" type="x-shader/x-fragment">


### PR DESCRIPTION
This reintroduces the previous color scheme from the THREE.js material in the shader.

![Screenshot_2024-02-06_10-23-35](https://github.com/philipswan/TetheredRing/assets/29463033/4bb8607d-8e41-419f-9558-1ab2a1b4f728)

